### PR TITLE
style: apply formatting for upstream PR 3907

### DIFF
--- a/.github/workflows/reusable-checks.yml
+++ b/.github/workflows/reusable-checks.yml
@@ -84,17 +84,25 @@ jobs:
           git diff --binary > formatting.patch
           git diff --cached --binary >> formatting.patch
 
-      - name: Upload formatting patch
+      - name: Apply formatting with autofix.ci
+        id: autofix
         if: steps.formatting-diff.outputs.has_changes == 'true' && github.event_name == 'pull_request'
+        uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a
+        continue-on-error: true
+        with:
+          commit-message: "style: auto-formatting (clang/stylua/cmake)"
+
+      - name: Upload formatting patch
+        if: steps.formatting-diff.outputs.has_changes == 'true' && steps.autofix.outputs.autofix_started != 'true' && github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: formatting.patch
           path: formatting.patch
 
       - name: Fail on formatting changes
-        if: steps.formatting-diff.outputs.has_changes == 'true'
+        if: steps.formatting-diff.outputs.has_changes == 'true' && steps.autofix.outputs.autofix_started != 'true'
         run: |
-          echo "::error::Formatting changes are required. Apply the formatting.patch artifact or run the formatters locally and push the result."
+          echo "::error::Formatting changes are required. Install/configure autofix.ci or apply the formatting.patch artifact and push the result."
           exit 1
 
       - name: Run Analysis (Reviewdog)

--- a/data-otservbr-global/scripts/quests/heart_of_destruction/movements_teleport_heart.lua
+++ b/data-otservbr-global/scripts/quests/heart_of_destruction/movements_teleport_heart.lua
@@ -18,17 +18,17 @@ local vortexTeleports = {
 	[14323] = { -- Anomaly
 		position = Position(32246, 31252, 14),
 		storage = 14320,
-		boss = "Anomaly"
+		boss = "Anomaly",
 	},
 	[14342] = { -- Rupture
 		position = Position(32305, 31249, 14),
 		storage = 14322,
-		boss = "Rupture"
+		boss = "Rupture",
 	},
 	[14344] = { -- Realityquake
 		position = Position(32181, 31240, 14),
 		storage = 14324,
-		boss = "Realityquake"
+		boss = "Realityquake",
 	},
 
 	[14346] = { -- Eradicator
@@ -36,18 +36,18 @@ local vortexTeleports = {
 		storage1 = 14326,
 		storage2 = 14327,
 		storage3 = 14328,
-		boss = "Eradicator"
+		boss = "Eradicator",
 	},
 	[14349] = { -- Outburst
 		position = Position(32204, 31290, 14),
 		storage1 = 14326,
 		storage2 = 14327,
 		storage3 = 14328,
-		boss = "Outburst"
+		boss = "Outburst",
 	},
 
 	[14351] = { special = "worldDevourerEnter" },
-	[14353] = { special = "worldDevourerExit" }
+	[14353] = { special = "worldDevourerExit" },
 }
 
 local function denyAndReturn(player, fromPosition, message)
@@ -76,9 +76,7 @@ function teleportHeart.onStepIn(creature, item, position, fromPosition)
 			denyAndReturn(player, fromPosition, "You don't have access to this portal.")
 		end
 	elseif data.storage1 then
-		if player:getStorageValue(data.storage1) >= 1 and
-		   player:getStorageValue(data.storage2) >= 1 and
-		   player:getStorageValue(data.storage3) >= 1 then
+		if player:getStorageValue(data.storage1) >= 1 and player:getStorageValue(data.storage2) >= 1 and player:getStorageValue(data.storage3) >= 1 then
 			if player:canFightBoss(data.boss) then
 				player:teleportTo(data.position)
 			else

--- a/data/scripts/actions/items/cup_of_molten_gold.lua
+++ b/data/scripts/actions/items/cup_of_molten_gold.lua
@@ -1,15 +1,15 @@
 local cupOfMoltenGold = Action()
 
 local config = {
-    goldenFirCone = 12550,
-    [3614] = {
-        successMsg = "Carefully you drizzle some of the gold on top of the finest fir cone you could find on this tree.",
-        failMsg = "Drizzling all over a fir cone you picked from the tree, the molten gold only covers about half of it - not enough."
-    },
-    [19111] = {
-        successMsg = "Carefully you drizzle some of the gold on top of the fir cone.",
-        failMsg = "Drizzling all over the fir cone, the molten gold only covers about half of it - not enough."
-    }
+	goldenFirCone = 12550,
+	[3614] = {
+		successMsg = "Carefully you drizzle some of the gold on top of the finest fir cone you could find on this tree.",
+		failMsg = "Drizzling all over a fir cone you picked from the tree, the molten gold only covers about half of it - not enough.",
+	},
+	[19111] = {
+		successMsg = "Carefully you drizzle some of the gold on top of the fir cone.",
+		failMsg = "Drizzling all over the fir cone, the molten gold only covers about half of it - not enough.",
+	},
 }
 
 function cupOfMoltenGold.onUse(player, item, fromPosition, target, toPosition, isHotkey)
@@ -36,7 +36,7 @@ function cupOfMoltenGold.onUse(player, item, fromPosition, target, toPosition, i
 		item:remove(1)
 		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, targetConfig.failMsg)
 	end
-return true
+	return true
 end
 
 cupOfMoltenGold:id(12804)


### PR DESCRIPTION
Applies the formatting patch generated by the upstream Canary CI for opentibiabr/canary#3907 and adds CI autofix support for future formatter diffs.\n\nChanges included:\n- StyLua formatting in \cup_of_molten_gold.lua\\n- StyLua formatting in \movements_teleport_heart.lua\\n- Adds \utofix-ci/action\ after formatter diff detection so future PR formatting changes can be committed automatically when the app is installed/configured\n\nMerging this into \Small-Fixes-and-Additions\ should unblock the upstream PR fast checks. For the automatic formatter commits to work on future fork PRs, install the autofix.ci GitHub App on the upstream repository.